### PR TITLE
Update pyproject.toml to specify minimum python version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install additional dependencies and this package
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
     {name = "Phong Le", email = "levuvietphong@gmail.com"}
 ]
 readme = "README-pypi.md"
+requires-python = ">=3.11"
 
 dependencies = [
     "cartopy",


### PR DESCRIPTION
As suggested in the review of https://github.com/openjournals/joss-reviews/issues/8074#issuecomment-2892052929 this provides a more complete solution to #23 by enforcing at install the documentation requirement that Python >= 3.11 is required (see https://github.com/levuvietphong/pyTCR/commit/35e98be18eb8984771fafbd13b00f9d46a3588d1).